### PR TITLE
refactor: adjust layout properties for HeroSection and Navbar components

### DIFF
--- a/src/components/Hero/HeroSection.tsx
+++ b/src/components/Hero/HeroSection.tsx
@@ -10,7 +10,7 @@ export default function HeroSection() {
       style={{ backgroundImage: "url('/herosection.jpeg')" }}
     >
       <div className="absolute inset-0 bg-black opacity-60 z-0 backdrop-blur-md"></div>
-      <div className="relative z-10">
+      <div className="relative z-10 flex flex-col justify-center items-center min-h-screen pt-24">
         <HeroTitleAndDescription />
         <HeroButton />
         <div className="w-full flex flex-col md:flex-row flex-wrap md:flex-nowrap justify-center items-center gap-12 md:gap-20 mt-10">

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 
 export default function Navbar() {
   return (
-    <nav className="sticky top-0 flex flex-col md:flex-row items-center justify-between bg-transparent backdrop-blur-md font-sans border-b shadow-lg px-6 z-50">
+    <nav className="fixed top-0 flex items-center justify-between bg-transparent backdrop-blur-md border-b shadow-lg px-6 z-50 w-full">
       <div className="flex items-center space-x-6 md:space-x-4">
         <ChartColumn
           className="w-6 h-6 md:w-12 md:h-12 p-1.5 rounded-4xl text-white mx-auto"/>


### PR DESCRIPTION
The hero section contents are now vertically centered and have top padding (`pt-24`) to prevent them from being hidden behind the fixed navbar. This ensures the content is always visible and centered on the screen.